### PR TITLE
Issue #9 - Deactivate Queue via Chat Command

### DIFF
--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -25,6 +25,7 @@ export class TeamsBot extends TeamsActivityHandler {
     super();
 
     this.likeCountObj = { likeCount: 0 };
+    this.activeQueue = null;
 
     this.onMessage(async (context, next) => {
       console.log("Running with Message Activity.");
@@ -41,18 +42,35 @@ export class TeamsBot extends TeamsActivityHandler {
       // Trigger command by IM text
       switch (txt) {
         case "start office hour": {
-          this.activeQueue = new Queue({
-            ownerId: context.activity.from.id,
-            channelId: context.activity.channelId,
-          });
-          await context.sendActivity(
-            "<b>Started new Queue<b>\n\n" +
-              `<b>id</b>        ${this.activeQueue.properties.id}\n\n` +
-              `<b>ownerId</b>   ${this.activeQueue.properties.ownerId}\n\n` +
-              `<b>channelId</b> ${this.activeQueue.properties.channelId}\n\n` +
-              `<b>status</b>    ${this.activeQueue.properties.status}\n\n` +
-              `<b>at</b>        ${this.activeQueue.properties.startTime}`
-          );
+          if (this.activeQueue) {
+            await context.sendActivity(
+              'Office hour already in progress. End active office hour with the command "end office hour"'
+            );
+          } else {
+            this.activeQueue = new Queue({
+              ownerId: context.activity.from.id,
+              channelId: context.activity.channelId,
+            });
+            await context.sendActivity(
+              "<b>Started new Queue<b>\n\n" +
+                `<b>id</b>        ${this.activeQueue.properties.id}\n\n` +
+                `<b>ownerId</b>   ${this.activeQueue.properties.ownerId}\n\n` +
+                `<b>channelId</b> ${this.activeQueue.properties.channelId}\n\n` +
+                `<b>status</b>    ${this.activeQueue.properties.status}\n\n` +
+                `<b>at</b>        ${this.activeQueue.properties.startTime}`
+            );
+          }
+          break;
+        }
+        case "end office hour": {
+          if (this.activeQueue) {
+            this.activeQueue = null;
+            await context.sendActivity("Office hour successfully ended.");
+          } else {
+            await context.sendActivity(
+              'No office hour currently active. Start an office hour with the command "start office hour"'
+            );
+          }
           break;
         }
       }

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -53,6 +53,7 @@ export class TeamsBot extends TeamsActivityHandler {
               `<b>status</b>    ${this.activeQueue.properties.status}\n\n` +
               `<b>at</b>        ${this.activeQueue.properties.startTime}`
           );
+          break;
         }
       }
 

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -40,24 +40,6 @@ export class TeamsBot extends TeamsActivityHandler {
 
       // Trigger command by IM text
       switch (txt) {
-        case "welcome": {
-          const card =
-            AdaptiveCards.declareWithoutData(rawWelcomeCard).render();
-          await context.sendActivity({
-            attachments: [CardFactory.adaptiveCard(card)],
-          });
-          break;
-        }
-        case "learn": {
-          this.likeCountObj.likeCount = 0;
-          const card = AdaptiveCards.declare<DataInterface>(
-            rawLearnCard
-          ).render(this.likeCountObj);
-          await context.sendActivity({
-            attachments: [CardFactory.adaptiveCard(card)],
-          });
-          break;
-        }
         case "start office hour": {
           this.activeQueue = new Queue({
             ownerId: context.activity.from.id,
@@ -72,12 +54,6 @@ export class TeamsBot extends TeamsActivityHandler {
               `<b>at</b>        ${this.activeQueue.properties.startTime}`
           );
         }
-        /**
-         * case "yourCommand": {
-         *   await context.sendActivity(`Add your response here!`);
-         *   break;
-         * }
-         */
       }
 
       // By calling next() you ensure that the next BotHandler is run.

--- a/templates/appPackage/manifest.local.template.json
+++ b/templates/appPackage/manifest.local.template.json
@@ -34,14 +34,6 @@
           "scopes": ["personal", "team", "groupchat"],
           "commands": [
             {
-              "title": "welcome",
-              "description": "Resend welcome card of this Bot"
-            },
-            {
-              "title": "learn",
-              "description": "Learn about Adaptive Card and Bot Command"
-            },
-            {
               "title": "start office hour",
               "description": "Start a new office hour queue"
             }

--- a/templates/appPackage/manifest.local.template.json
+++ b/templates/appPackage/manifest.local.template.json
@@ -36,6 +36,10 @@
             {
               "title": "start office hour",
               "description": "Start a new office hour queue"
+            },
+            {
+              "title": "end office hour",
+              "description": "End the active office hour queue"
             }
           ]
         }

--- a/templates/appPackage/manifest.remote.template.json
+++ b/templates/appPackage/manifest.remote.template.json
@@ -34,14 +34,6 @@
           "scopes": ["personal", "team", "groupchat"],
           "commands": [
             {
-              "title": "welcome",
-              "description": "Resend welcome card of this Bot"
-            },
-            {
-              "title": "learn",
-              "description": "Learn about Adaptive Card and Bot Command"
-            },
-            {
               "title": "start office hour",
               "description": "Start a new office hour queue"
             }

--- a/templates/appPackage/manifest.remote.template.json
+++ b/templates/appPackage/manifest.remote.template.json
@@ -36,6 +36,10 @@
             {
               "title": "start office hour",
               "description": "Start a new office hour queue"
+            },
+            {
+              "title": "end office hour",
+              "description": "End the active office hour queue"
             }
           ]
         }


### PR DESCRIPTION
Fixes #9  - Deactivate Queue via Chat Command

This PR removes the boilerplate commands ("welcome" and "learn") from the bot and adds a new command, "end office hour", which sets the `TeamsBot` object's `activeQueue` data member to `null` if it is a truthy value (i.e., a Queue is active). In addition, the logic for the "start office hour" command was refined to only start a new Queue if the `activeQueue` data member is a falsy value (i.e., `null`).

![image](https://user-images.githubusercontent.com/17690570/150004417-d7060111-2528-47dd-be4a-10a9bd987092.png)
