### PR TITLE
Remove student queue

### DIFF
--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -81,7 +81,10 @@ export class TeamsBot extends TeamsActivityHandler {
             } else {
               this.activeQueue.enqueueStudent(context.activity.from.id);
               await context.sendActivity(
-                `You have entered the office hours queue, the instructor will get to you!\nYou are in position ${this.activeQueue.length}.`
+                `You have entered the office hours queue, the instructor will get to you!\nYou are in position ${
+                  this.activeQueue.getQueuePosition(context.activity.from.id) +
+                  1
+                }.`
               );
               await context.sendActivity(
                 `Current queue: ${this.activeQueue.queueToString()}`
@@ -93,6 +96,24 @@ export class TeamsBot extends TeamsActivityHandler {
             );
           }
           break;
+        }
+        case "leave office hours": {
+          if (this.activeQueue) {
+            if (!this.activeQueue.checkQueue(context.activity.from.id)) {
+              await context.sendActivity(
+                "Unable to remove, you are currently not in a queue."
+              );
+            } else {
+              this.activeQueue.dequeueStudent(context.activity.from.id);
+              await context.sendActivity(
+                `You have successfully been removed from the queue.\n Current queue: ${this.activeQueue.queueToString()}`
+              );
+            }
+          } else {
+            await context.sendActivity(
+              "Currently no office hours being held. Please check the schedule to confirm the next office hours session!"
+            );
+          }
         }
       }
 

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -81,7 +81,7 @@ export class TeamsBot extends TeamsActivityHandler {
             } else {
               this.activeQueue.enqueueStudent(context.activity.from.id);
               await context.sendActivity(
-                `You have entered the office hours queue, the instructor will get to you!\nYou are in position ${
+                `You have entered the office hours queue, the instructor will get to you! You are in position ${
                   this.activeQueue.getQueuePosition(context.activity.from.id) +
                   1
                 }.`
@@ -106,7 +106,7 @@ export class TeamsBot extends TeamsActivityHandler {
             } else {
               this.activeQueue.dequeueStudent(context.activity.from.id);
               await context.sendActivity(
-                `You have successfully been removed from the queue.\n Current queue: ${this.activeQueue.queueToString()}`
+                `You have successfully been removed from the queue.<br>Current queue: ${this.activeQueue.queueToString()}`
               );
             }
           } else {

--- a/bot/utilities/Queue.ts
+++ b/bot/utilities/Queue.ts
@@ -53,13 +53,19 @@ export class Queue {
     return this.entries.length;
   }
 
+  findStudent(idToFind: string): QueueEntry {
+    return this.entries.find((student) => student.userId == idToFind);
+  }
+
   checkQueue(idToCheck: string): boolean {
-    if (
-      this.entries.find((student) => student.userId == idToCheck) != undefined
-    ) {
+    if (this.findStudent(idToCheck) != undefined) {
       return true;
     }
     return false;
+  }
+
+  getQueuePosition(idToGet: string): number {
+    return this.entries.indexOf(this.findStudent(idToGet));
   }
 
   enqueueStudent(idToAdd: string): void {
@@ -73,6 +79,10 @@ export class Queue {
       // leaving updatedAt for post-creation updates only
     };
     this.entries.push(studentToAdd);
+  }
+
+  dequeueStudent(idToRemove: string): void {
+    this.entries.splice(this.getQueuePosition(idToRemove), 1);
   }
 
   queueToString(): String {

--- a/templates/appPackage/manifest.local.template.json
+++ b/templates/appPackage/manifest.local.template.json
@@ -43,7 +43,11 @@
             },
             {
               "title": "join office hours",
-              "description": "Jump in line to get help from the instructor"
+              "description": "Jump in queue to get help from the instructor"
+            },
+            {
+              "title": "leave office hours",
+              "description": "Leave the office hours queue"
             }
           ]
         }

--- a/templates/appPackage/manifest.remote.template.json
+++ b/templates/appPackage/manifest.remote.template.json
@@ -43,7 +43,11 @@
             },
             {
               "title": "join office hours",
-              "description": "Jump in line to get help from the instructor"
+              "description": "Jump in queue to get help from the instructor"
+            },
+            {
+              "title": "leave office hours",
+              "description": "Leave the office hours queue"
             }
           ]
         }


### PR DESCRIPTION
Fixes #11.

Added functionality to remove students from an active office hours instance in `bot/teamsBot.ts`. Prevents removal from the queue if office hours are not active or student is not in an active office hours queue. 

Supporting functionality of finding a student within a queue, getting student's queue position, and checking whether the student is a member of a queue was either added or refactored within the Queue class located at `utilities/Queue.ts`.

![image](https://user-images.githubusercontent.com/40576340/150426665-5b36eef4-f3b8-4a5c-a3d0-a69553c32fa0.png)
