### PR TITLE
update queue status in db

### DIFF
--- a/bot/api/updateQueueStatusInDb.ts
+++ b/bot/api/updateQueueStatusInDb.ts
@@ -1,17 +1,17 @@
-import { Connection } from 'typeorm';
-import Queue from '../utilities/Queue';
-import { QueueEntity } from '../entities/queue';
+import { Connection } from "typeorm";
+import Queue from "../utilities/Queue";
+import { QueueEntity } from "../entities/queue";
 
 export default async (conn: Connection, queue: Queue) => {
-    try {
-        await conn
-            .createQueryBuilder()
-            .update(QueueEntity)
-            .set({ status: queue.properties.status })
-            .where('id = :id', { id: queue.properties.id })
-            .execute();
-    } catch (e) {
-        console.log('Failed to update Queue in Database', e);
-        throw e;
-    }
+  try {
+    await conn
+      .createQueryBuilder()
+      .update(QueueEntity)
+      .set({ status: queue.properties.status })
+      .where("id = :id", { id: queue.properties.id })
+      .execute();
+  } catch (e) {
+    console.log("Failed to update Queue in Database", e);
+    throw e;
+  }
 };

--- a/bot/api/updateQueueStatusInDb.ts
+++ b/bot/api/updateQueueStatusInDb.ts
@@ -1,0 +1,17 @@
+import { Connection } from 'typeorm';
+import Queue from '../utilities/Queue';
+import { QueueEntity } from '../entities/queue';
+
+export default async (conn: Connection, queue: Queue) => {
+    try {
+        await conn
+            .createQueryBuilder()
+            .update(QueueEntity)
+            .set({ status: queue.properties.status })
+            .where('id = :id', { id: queue.properties.id })
+            .execute();
+    } catch (e) {
+        console.log('Failed to update Queue in Database', e);
+        throw e;
+    }
+};

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -11,6 +11,8 @@ import addQueueEntryToDb from "./api/addQueueEntryToDb";
 import addQueueToDb from "./api/addQueueToDb";
 import fetchQueuesByOwner from "./api/fetchQueuesByOwner";
 import fetchQueueEntriesByQueueId from "./api/fetchQueueEntriesByQueueId";
+import updateQueueStatusInDb from "./api/updateQueueStatusInDb";
+import { QueueStatus } from "./utilities/Global";
 import Queue from "./utilities/Queue";
 
 export interface DataInterface {
@@ -76,6 +78,8 @@ export class TeamsBot extends TeamsActivityHandler {
         }
         case "end office hour": {
           if (this.activeQueue) {
+            this.activeQueue.updateStatus(QueueStatus.Closed);
+            await updateQueueStatusInDb(this.dbConnection, this.activeQueue);
             this.activeQueue = null;
             await context.sendActivity("Office hour successfully ended.");
           } else {

--- a/bot/utilities/Queue.ts
+++ b/bot/utilities/Queue.ts
@@ -32,6 +32,10 @@ export default class Queue {
     this.properties.id = queueId;
   }
 
+  updateStatus(queueStatus: QueueStatus) {
+    this.properties.status = queueStatus;
+  }
+
   get length(): number {
     return this.entries.length;
   }


### PR DESCRIPTION
closes #35 

This PR creates a function to update the queue status in the database. It also adds a method on the Queue object to update the status of the queue. 

These methods have been applied to the case when a user ends an office hour. They could be potentially used for other instances so they have been left generic. 