### PR TITLE
ISSUE #49 add dotenv to regular dependencies

### DIFF
--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -1828,10 +1828,9 @@
       }
     },
     "dotenv": {
-      "version": "14.3.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
-      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
-      "dev": true
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
     },
     "dtrace-provider": {
       "version": "0.8.8",

--- a/bot/package.json
+++ b/bot/package.json
@@ -19,6 +19,7 @@
     "@microsoft/adaptivecards-tools": "^0.1.2",
     "botbuilder": "~4.14.0",
     "botbuilder-dialogs": "~4.14.0",
+    "dotenv": "^16.0.0",
     "isomorphic-fetch": "^3.0.0",
     "mssql": "^7.3.0",
     "restify": "^8.5.1",
@@ -26,7 +27,6 @@
   },
   "devDependencies": {
     "@types/restify": "8.4.2",
-    "dotenv": "^14.3.2",
     "ngrok": "^3.4.0",
     "nodemon": "^2.0.7",
     "shx": "^0.3.3",


### PR DESCRIPTION
closes #49.

The deployed app is trying to import dotenv right now but it was just a dev dependency so it was failing. This PR fixes that issue. 