### PR TITLE
Mark chat resolved (Issue #27) and get next student (Issue #66)

### DIFF
--- a/bot/api/addQueueEntryToDb.ts
+++ b/bot/api/addQueueEntryToDb.ts
@@ -1,5 +1,6 @@
 import { Connection } from "typeorm";
 import { QueueEntryEntity } from "../entities/queueEntry";
+import { StudentStatus } from "../utilities/Global";
 
 interface queueEntryOptions {
   question?: string;
@@ -14,7 +15,7 @@ export default async (
 ) => {
   try {
     const inputValues = {
-      resolved: false,
+      resolved: StudentStatus.Waiting,
       queue: queueId,
       userId: userId,
       ...options,

--- a/bot/api/updateQueueEntryResolved.ts
+++ b/bot/api/updateQueueEntryResolved.ts
@@ -1,0 +1,18 @@
+import { Connection } from "typeorm";
+import { QueueEntryEntity } from "../entities/queueEntry";
+import { StudentStatus } from "../utilities/Global";
+
+export default async (conn: Connection, id: number) => {
+    try{
+        const result = await conn
+            .createQueryBuilder()
+            .update(QueueEntryEntity)
+            .set({ resolved: StudentStatus.Resolved, })
+            .where("id = :id", { id })
+            .execute();
+        return result;
+    } catch (e) {
+        console.log(`Failed to update Resolved state of student ${id}:`, e);
+        throw e;
+    }
+}

--- a/bot/api/updateQueueEntryResolved.ts
+++ b/bot/api/updateQueueEntryResolved.ts
@@ -2,17 +2,17 @@ import { Connection } from "typeorm";
 import { QueueEntryEntity } from "../entities/queueEntry";
 import { StudentStatus } from "../utilities/Global";
 
-export default async (conn: Connection, id: number) => {
+export default async (conn: Connection, id: number, status: StudentStatus) => {
     try{
         const result = await conn
             .createQueryBuilder()
             .update(QueueEntryEntity)
-            .set({ resolved: StudentStatus.Resolved, })
+            .set({ resolved: status, })
             .where("id = :id", { id })
             .execute();
         return result;
     } catch (e) {
-        console.log(`Failed to update Resolved state of student ${id}:`, e);
+        console.log(`Failed to update student's resolved state ${id}:`, e);
         throw e;
     }
 }

--- a/bot/api/updateQueueEntryResolved.ts
+++ b/bot/api/updateQueueEntryResolved.ts
@@ -3,16 +3,16 @@ import { QueueEntryEntity } from "../entities/queueEntry";
 import { StudentStatus } from "../utilities/Global";
 
 export default async (conn: Connection, id: number, status: StudentStatus) => {
-    try{
-        const result = await conn
-            .createQueryBuilder()
-            .update(QueueEntryEntity)
-            .set({ resolved: status, })
-            .where("id = :id", { id })
-            .execute();
-        return result;
-    } catch (e) {
-        console.log(`Failed to update student's resolved state ${id}:`, e);
-        throw e;
-    }
-}
+  try {
+    const result = await conn
+      .createQueryBuilder()
+      .update(QueueEntryEntity)
+      .set({ resolved: status })
+      .where("id = :id", { id })
+      .execute();
+    return result;
+  } catch (e) {
+    console.log(`Failed to update student's resolved state ${id}:`, e);
+    throw e;
+  }
+};

--- a/bot/entities/queueEntry.ts
+++ b/bot/entities/queueEntry.ts
@@ -8,6 +8,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
+import { StudentStatus } from "../utilities/Global";
 import { QueueEntity } from "./queue";
 
 @Entity("queueEntry")
@@ -25,7 +26,7 @@ export class QueueEntryEntity extends BaseEntity {
   question: string | null;
 
   @Column()
-  resolved: boolean;
+  resolved: StudentStatus;
 
   @CreateDateColumn()
   createdAt: Date = new Date();

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -215,6 +215,10 @@ export class TeamsBot extends TeamsActivityHandler {
             );
           } else {
             const nextInLine = this.activeQueue.findFirstWaiting();
+            if (nextInLine == undefined) {
+                await context.sendActivity("There are no students in queue looking for help right now.");
+                break;
+            }
             nextInLine.setResolvedState(StudentStatus.Conversing);
             const updateResult = await updateQueueEntryResolved(
               this.dbConnection,
@@ -223,7 +227,7 @@ export class TeamsBot extends TeamsActivityHandler {
             );
             console.log(`Updated: ${updateResult}`);
             await context.sendActivity(
-              `Next to student to be helped:${nextInLine.toString()}`
+              `Next student to be helped:${nextInLine.toString()}`
             );
             // future functionality to automatically place new student into meeting/chat with instructor
           }

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -13,8 +13,14 @@ import fetchQueuesByOwner from "./api/fetchQueuesByOwner";
 import fetchQueueEntriesByQueueId from "./api/fetchQueueEntriesByQueueId";
 import updateQueueStatusInDb from "./api/updateQueueStatusInDb";
 import { QueueStatus } from "./utilities/Global";
+import updateQueueEntryResolved from "./api/updateQueueEntryResolved";
 import Queue from "./utilities/Queue";
+<<<<<<< HEAD
 import { getNamesOfTeamMembers } from "./api/getNamesOfTeamMembers";
+=======
+import QueueEntry from "./utilities/QueueEntry";
+import { StudentStatus } from "./utilities/Global";
+>>>>>>> 124cd62 (mark student complete command started, untested, setResolvedState added to QueueEntry)
 
 export interface DataInterface {
   likeCount: number;
@@ -174,12 +180,18 @@ export class TeamsBot extends TeamsActivityHandler {
             throw e;
           }
         }
-        case "student complete": {
-            // can only mark a student as complete if there is a student marked as conversing
+        case "mark student complete": {
+            // can only mark a student as complete if there is a student marked as conversing in the non-empty queue
             // only one student in a conversing state at a time
             // iterate over queue and pass the student that is currently conversing into queue
-            // const studentToUpdate: QueueEntry = this.activeQueue.findFirstConversing();
-
+            const studentToUpdate: QueueEntry = this.activeQueue.findFirstConversing();
+            if (studentToUpdate != undefined && this.activeQueue.length > 0) {
+                studentToUpdate.setResolvedState(StudentStatus.Resolved);
+                const updateResult = await updateQueueEntryResolved(this.dbConnection, studentToUpdate.id);
+                await context.sendActivity(`Student conversation resolved:${studentToUpdate.toString()}`);
+            } else {
+                await context.sendActivity("There are either no students conversing with an instructor or no students are in line.");
+            }
         }
       }
       if (txt.startsWith("private join office hours")) {

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -174,6 +174,13 @@ export class TeamsBot extends TeamsActivityHandler {
             throw e;
           }
         }
+        case "student complete": {
+            // can only mark a student as complete if there is a student marked as conversing
+            // only one student in a conversing state at a time
+            // iterate over queue and pass the student that is currently conversing into queue
+            // const studentToUpdate: QueueEntry = this.activeQueue.findFirstConversing();
+
+        }
       }
       if (txt.startsWith("private join office hours")) {
         try {

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -181,16 +181,14 @@ export class TeamsBot extends TeamsActivityHandler {
           }
         }
         case "mark student complete": {
-            // can only mark a student as complete if there is a student marked as conversing in the non-empty queue
-            // only one student in a conversing state at a time
-            // iterate over queue and pass the student that is currently conversing into queue
+            // only one student at a time can be in a conversing state 
             const studentToUpdate: QueueEntry = this.activeQueue.findFirstConversing();
-            if (studentToUpdate != undefined && this.activeQueue.length > 0) {
+            if (studentToUpdate != undefined && this.activeQueue.isNotEmpty()) {
                 studentToUpdate.setResolvedState(StudentStatus.Resolved);
                 const updateResult = await updateQueueEntryResolved(this.dbConnection, studentToUpdate.id);
                 await context.sendActivity(`Student conversation resolved:${studentToUpdate.toString()}`);
             } else {
-                await context.sendActivity("There are either no students conversing with an instructor or no students are in line.");
+                await context.sendActivity("Unable to mark student as completed - there are either no students conversing with an instructor or no students are in line.");
             }
         }
       }

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -15,12 +15,9 @@ import updateQueueStatusInDb from "./api/updateQueueStatusInDb";
 import { QueueStatus } from "./utilities/Global";
 import updateQueueEntryResolved from "./api/updateQueueEntryResolved";
 import Queue from "./utilities/Queue";
-<<<<<<< HEAD
 import { getNamesOfTeamMembers } from "./api/getNamesOfTeamMembers";
-=======
 import QueueEntry from "./utilities/QueueEntry";
 import { StudentStatus } from "./utilities/Global";
->>>>>>> 124cd62 (mark student complete command started, untested, setResolvedState added to QueueEntry)
 
 export interface DataInterface {
   likeCount: number;
@@ -179,6 +176,7 @@ export class TeamsBot extends TeamsActivityHandler {
             console.error('Error performing command "view queue"\n' + e);
             throw e;
           }
+          break;
         }
         case "mark student complete": {
           // only one student at a time can be in a conversing state

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -181,41 +181,53 @@ export class TeamsBot extends TeamsActivityHandler {
           }
         }
         case "mark student complete": {
-            // only one student at a time can be in a conversing state 
-            const studentToUpdate: QueueEntry = this.activeQueue.findFirstConversing();
-            if (studentToUpdate != undefined && this.activeQueue.isNotEmpty()) {
-                studentToUpdate.setResolvedState(StudentStatus.Resolved);
-                const updateResult = await updateQueueEntryResolved(
-                    this.dbConnection, 
-                    studentToUpdate.id, 
-                    studentToUpdate.resolved
-                );
-                console.log(`Updated: ${updateResult}`);
-                await context.sendActivity(`Student conversation resolved:${studentToUpdate.toString()}`);
-            } else {
-                await context.sendActivity("Unable to mark student as completed - there are either no students conversing with an instructor or no students are in line.");
-            }
-            break;
+          // only one student at a time can be in a conversing state
+          const studentToUpdate: QueueEntry =
+            this.activeQueue.findFirstConversing();
+          if (studentToUpdate != undefined && this.activeQueue.isNotEmpty()) {
+            studentToUpdate.setResolvedState(StudentStatus.Resolved);
+            const updateResult = await updateQueueEntryResolved(
+              this.dbConnection,
+              studentToUpdate.id,
+              studentToUpdate.resolved
+            );
+            console.log(`Updated: ${updateResult}`);
+            await context.sendActivity(
+              `Student conversation resolved:${studentToUpdate.toString()}`
+            );
+          } else {
+            await context.sendActivity(
+              "Unable to mark student as completed - there are either no students conversing with an instructor or no students are in line."
+            );
+          }
+          break;
         }
-        case "get next student":{
-            const anyConversing : QueueEntry = this.activeQueue.findFirstConversing();
-            if (anyConversing != undefined) {
-                await context.sendActivity(`Have you finished helping the other student? Please resolve the conversation with the current student via 'mark student complete'. Currently needs resolving: ${anyConversing.toString()}`);
-            } else if (this.activeQueue.isEmpty()) {
-                await context.sendActivity("There are currently no students in line!");
-            } else {
-               const nextInLine = this.activeQueue.findFirstWaiting();
-               nextInLine.setResolvedState(StudentStatus.Conversing);
-               const updateResult = await updateQueueEntryResolved(
-                   this.dbConnection, 
-                   nextInLine.id,
-                   nextInLine.resolved
-                );
-               console.log(`Updated: ${updateResult}`);
-               await context.sendActivity(`Next to student to be helped:${nextInLine.toString()}`)
-                // future functionality to automatically place new student into meeting/chat with instructor
-            }
-            break;
+        case "get next student": {
+          const anyConversing: QueueEntry =
+            this.activeQueue.findFirstConversing();
+          if (anyConversing != undefined) {
+            await context.sendActivity(
+              `Have you finished helping the other student? Please resolve the conversation with the current student via 'mark student complete'. Currently needs resolving: ${anyConversing.toString()}`
+            );
+          } else if (this.activeQueue.isEmpty()) {
+            await context.sendActivity(
+              "There are currently no students in line!"
+            );
+          } else {
+            const nextInLine = this.activeQueue.findFirstWaiting();
+            nextInLine.setResolvedState(StudentStatus.Conversing);
+            const updateResult = await updateQueueEntryResolved(
+              this.dbConnection,
+              nextInLine.id,
+              nextInLine.resolved
+            );
+            console.log(`Updated: ${updateResult}`);
+            await context.sendActivity(
+              `Next to student to be helped:${nextInLine.toString()}`
+            );
+            // future functionality to automatically place new student into meeting/chat with instructor
+          }
+          break;
         }
       }
       if (txt.startsWith("private join office hours")) {

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -184,7 +184,7 @@ export class TeamsBot extends TeamsActivityHandler {
           // only one student at a time can be in a conversing state
           const studentToUpdate: QueueEntry =
             this.activeQueue.findFirstConversing();
-          if (studentToUpdate != undefined && this.activeQueue.isNotEmpty()) {
+          if (studentToUpdate != undefined && !this.activeQueue.isEmpty()) {
             studentToUpdate.setResolvedState(StudentStatus.Resolved);
             const updateResult = await updateQueueEntryResolved(
               this.dbConnection,

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -216,8 +216,10 @@ export class TeamsBot extends TeamsActivityHandler {
           } else {
             const nextInLine = this.activeQueue.findFirstWaiting();
             if (nextInLine == undefined) {
-                await context.sendActivity("There are no students in queue looking for help right now.");
-                break;
+              await context.sendActivity(
+                "There are no students in queue looking for help right now."
+              );
+              break;
             }
             nextInLine.setResolvedState(StudentStatus.Conversing);
             const updateResult = await updateQueueEntryResolved(

--- a/bot/utilities/Global.ts
+++ b/bot/utilities/Global.ts
@@ -23,3 +23,9 @@ export interface QueueProperties {
   startTime?: Date;
   status?: QueueStatus;
 }
+
+export enum StudentStatus {
+    Waiting = "WAITING",
+    Conversing = "CONVERSING",
+    Resolved = "RESOLVED"
+}

--- a/bot/utilities/Global.ts
+++ b/bot/utilities/Global.ts
@@ -25,7 +25,7 @@ export interface QueueProperties {
 }
 
 export enum StudentStatus {
-    Waiting = "WAITING",
-    Conversing = "CONVERSING",
-    Resolved = "RESOLVED"
+  Waiting = "WAITING",
+  Conversing = "CONVERSING",
+  Resolved = "RESOLVED",
 }

--- a/bot/utilities/Queue.ts
+++ b/bot/utilities/Queue.ts
@@ -1,5 +1,5 @@
 import QueueEntry from "./QueueEntry";
-import { QueueProperties, QueueStatus } from "./Global";
+import { QueueProperties, QueueStatus, StudentStatus } from "./Global";
 import { QueueEntity } from "../entities/queue";
 import { QueueEntryEntity } from "../entities/queueEntry";
 
@@ -79,6 +79,10 @@ export default class Queue {
 
   dequeueStudent(idToRemove: string): void {
     this.entries.splice(this.getQueuePosition(idToRemove), 1);
+  }
+
+  findFirstConversing() : QueueEntry {
+      return this.entries.find((student) => student.resolved == StudentStatus.Conversing);
   }
 
   propertiesToString(): string {

--- a/bot/utilities/Queue.ts
+++ b/bot/utilities/Queue.ts
@@ -50,10 +50,6 @@ export default class Queue {
     return this.length == 0;
   }
 
-  isNotEmpty(): boolean {
-    return this.length != 0;
-  }
-
   findStudent(idToFind: string): QueueEntry {
     return this.entries.find((student) => student.userId == idToFind);
   }

--- a/bot/utilities/Queue.ts
+++ b/bot/utilities/Queue.ts
@@ -94,6 +94,10 @@ export default class Queue {
       return this.entries.find((student) => student.resolved == StudentStatus.Conversing);
   }
 
+  findFirstWaiting() : QueueEntry {
+      return this.entries.find((student) => student.resolved == StudentStatus.Waiting);
+  }
+
   propertiesToString(): string {
     return (
       `\n\n           id: ${this.properties.id}\n` +

--- a/bot/utilities/Queue.ts
+++ b/bot/utilities/Queue.ts
@@ -81,7 +81,7 @@ export default class Queue {
       queueId: this.properties.id,
       privateEntry: options.privateEntry ?? false,
       question: options.question ?? "",
-      resolved: false,
+      resolved: StudentStatus.Waiting,
     });
     this.entries.push(studentToAdd);
   }

--- a/bot/utilities/Queue.ts
+++ b/bot/utilities/Queue.ts
@@ -2,6 +2,7 @@ import QueueEntry from "./QueueEntry";
 import { QueueProperties, QueueStatus, StudentStatus } from "./Global";
 import { QueueEntity } from "../entities/queue";
 import { QueueEntryEntity } from "../entities/queueEntry";
+import { ThisMemoryScope } from "botbuilder-dialogs";
 
 interface enqueueOptions {
   privateEntry?: boolean;
@@ -43,6 +44,14 @@ export default class Queue {
 
   get length(): number {
     return this.entries.length;
+  }
+
+  isEmpty(): boolean {
+      return this.length == 0;
+  }
+
+  isNotEmpty(): boolean {
+      return this.length != 0;
   }
 
   findStudent(idToFind: string): QueueEntry {

--- a/bot/utilities/Queue.ts
+++ b/bot/utilities/Queue.ts
@@ -47,11 +47,11 @@ export default class Queue {
   }
 
   isEmpty(): boolean {
-      return this.length == 0;
+    return this.length == 0;
   }
 
   isNotEmpty(): boolean {
-      return this.length != 0;
+    return this.length != 0;
   }
 
   findStudent(idToFind: string): QueueEntry {
@@ -90,12 +90,16 @@ export default class Queue {
     this.entries.splice(this.getQueuePosition(idToRemove), 1);
   }
 
-  findFirstConversing() : QueueEntry {
-      return this.entries.find((student) => student.resolved == StudentStatus.Conversing);
+  findFirstConversing(): QueueEntry {
+    return this.entries.find(
+      (student) => student.resolved == StudentStatus.Conversing
+    );
   }
 
-  findFirstWaiting() : QueueEntry {
-      return this.entries.find((student) => student.resolved == StudentStatus.Waiting);
+  findFirstWaiting(): QueueEntry {
+    return this.entries.find(
+      (student) => student.resolved == StudentStatus.Waiting
+    );
   }
 
   propertiesToString(): string {

--- a/bot/utilities/QueueEntry.ts
+++ b/bot/utilities/QueueEntry.ts
@@ -24,8 +24,8 @@ export default class QueueEntry {
     this.queueId = queueId;
   }
 
-  setResolvedState(state: StudentStatus) : void {
-      this.resolved = state;
+  setResolvedState(state: StudentStatus): void {
+    this.resolved = state;
   }
 
   static fromQueueEntryEntity(queueEntryEntity: QueueEntryEntity): QueueEntry {

--- a/bot/utilities/QueueEntry.ts
+++ b/bot/utilities/QueueEntry.ts
@@ -24,6 +24,10 @@ export default class QueueEntry {
     this.queueId = queueId;
   }
 
+  setResolvedState(state: StudentStatus) : void {
+      this.resolved = state;
+  }
+
   static fromQueueEntryEntity(queueEntryEntity: QueueEntryEntity): QueueEntry {
     const entry = new QueueEntry({
       id: queueEntryEntity.id,

--- a/bot/utilities/QueueEntry.ts
+++ b/bot/utilities/QueueEntry.ts
@@ -1,4 +1,5 @@
 import { QueueEntryEntity } from "../entities/queueEntry";
+import { StudentStatus } from "./Global";
 
 export default class QueueEntry {
   id: number;
@@ -6,7 +7,7 @@ export default class QueueEntry {
   queueId: number;
   privateEntry: boolean;
   question: string;
-  resolved: boolean;
+  resolved: StudentStatus;
   createdAt: Date;
   updatedAt: Date;
 
@@ -16,7 +17,7 @@ export default class QueueEntry {
     this.queueId = queueId;
     this.privateEntry = privateEntry;
     this.question = question;
-    this.resolved = resolved;
+    this.resolved = StudentStatus.Waiting;
   }
 
   setQueueId(queueId: number): void {

--- a/templates/appPackage/manifest.local.template.json
+++ b/templates/appPackage/manifest.local.template.json
@@ -64,6 +64,10 @@
             {
                 "title": "mark student complete",
                 "description": "Mark the current student as resolved."
+            },
+            {
+                "title": "get next student",
+                "description": "Start helping the next student in line."
             }
           ]
         }

--- a/templates/appPackage/manifest.local.template.json
+++ b/templates/appPackage/manifest.local.template.json
@@ -62,12 +62,12 @@
               "description": "Show the list of students in the queue for the current office hour"
             },
             {
-                "title": "mark student complete",
-                "description": "Mark the current student as resolved."
+              "title": "mark student complete",
+              "description": "Mark the current student as resolved."
             },
             {
-                "title": "get next student",
-                "description": "Start helping the next student in line."
+              "title": "get next student",
+              "description": "Start helping the next student in line."
             }
           ]
         }

--- a/templates/appPackage/manifest.local.template.json
+++ b/templates/appPackage/manifest.local.template.json
@@ -60,6 +60,10 @@
             {
               "title": "view active queue",
               "description": "Show the list of students in the queue for the current office hour"
+            },
+            {
+                "title": "mark student complete",
+                "description": "Mark the current student as resolved."
             }
           ]
         }

--- a/templates/appPackage/manifest.remote.template.json
+++ b/templates/appPackage/manifest.remote.template.json
@@ -64,6 +64,10 @@
             {
                 "title": "mark student complete",
                 "description": "Mark the current student as resolved."
+            },
+            {
+                "title": "get next student",
+                "description": "Start helping the next student in line."
             }
           ]
         }

--- a/templates/appPackage/manifest.remote.template.json
+++ b/templates/appPackage/manifest.remote.template.json
@@ -62,12 +62,12 @@
               "description": "Show the list of students in the queue for the current office hour"
             },
             {
-                "title": "mark student complete",
-                "description": "Mark the current student as resolved."
+              "title": "mark student complete",
+              "description": "Mark the current student as resolved."
             },
             {
-                "title": "get next student",
-                "description": "Start helping the next student in line."
+              "title": "get next student",
+              "description": "Start helping the next student in line."
             }
           ]
         }

--- a/templates/appPackage/manifest.remote.template.json
+++ b/templates/appPackage/manifest.remote.template.json
@@ -60,6 +60,10 @@
             {
               "title": "view active queue",
               "description": "Show the list of students in the queue for the current office hour"
+            },
+            {
+                "title": "mark student complete",
+                "description": "Mark the current student as resolved."
             }
           ]
         }


### PR DESCRIPTION
This PR closes #27 and closes #66.

Changes/Features:
- `StudentStatus` enum representing the possible states a student can take in the office hours workflow ('WAITING', 'CONVERSING', 'RESOLVED') added to `bot/utilities/Global.ts`. This is reflected in the QueueEntry structure and the database.
- The database schema for `QueueEntry.resolved` field is changed from a `boolean` to `nvarchar`. Newly inserted entries contain a default `resolved` value of 'WAITING'. 
- `/bot/api/updateQueueEntryResolved.ts` contains the ORM mapping to update the `resolved` field.
- `mark student complete` and `get next student` bot commands that update the `resolved` fields appropriately. Enforces the idea that only one student can be in a `CONVERSING` state at a time and must be marked as `RESOLVED` before an instructor can move on and help the next student.
- supporting Queue and QueueEntry methods to accomplish the above.

Screenshots of functionality:
![image](https://user-images.githubusercontent.com/40576340/155056662-63136f92-9f75-4068-94d1-9ef062407d52.png)
![image](https://user-images.githubusercontent.com/40576340/155056719-b5198ce6-5abd-4961-91fc-88613b07651a.png)


