### PR TITLE
remove student from queue when marked complete

### DIFF
--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -197,8 +197,9 @@ export class TeamsBot extends TeamsActivityHandler {
               context,
               studentToUpdate.userId
             );
+            this.activeQueue.dequeueStudent(context.activity.from.id);
             await context.sendActivity(
-              `Conversation with ${member.name} is finished!`
+              `Conversation with ${member.name} is finished and he/she is removed from the queue.`
             );
           } else {
             await context.sendActivity(


### PR DESCRIPTION
Fixes bug for students remaining in the queue after being marked as complete, with appropriate output. 
![image](https://user-images.githubusercontent.com/40576340/156901149-32c6dc7e-f7cd-4328-a9d4-323f82ad7c18.png)
